### PR TITLE
Fixed breaking advmat2 for everything but singleplayer because of a typo

### DIFF
--- a/lua/autorun/sh_mateditor.lua
+++ b/lua/autorun/sh_mateditor.lua
@@ -218,7 +218,7 @@ function advMats:Set(ent, texture, data, submatid)
 		end
 		
 		if	(data.UseTreeSway) then
-			uid = uid .. (data.UseTreeSway) .. "+" .. data.TreeSwaySpeed .. "+" .. data.TreeSwayStrength .. data.TreeLeafSpeed .. "+" .. data.TreeLeafStrength .. "+" .. data.TreeSwayStartHeight .. "+" .. data.TreeSwayHeight .. "+" .. data.TreeSwayStartRadius .. "+" .. data.TreeSwayRadius
+			uid = uid .. (data.UseTreeSway) .. "+" .. data.TreeSwaySpeed .. "+" .. data.TreeSwayStrength .. "+" .. data.TreeLeafSpeed .. "+" .. data.TreeLeafStrength .. "+" .. data.TreeSwayStartHeight .. "+" .. data.TreeSwayHeight .. "+" .. data.TreeSwayStartRadius .. "+" .. data.TreeSwayRadius
 		end
 
 		uid = uid:gsub("%.", "-")


### PR DESCRIPTION
Bug introduced in https://github.com/ZH-Hristov/GMOD-Material-Editor-2/commit/9e1154a18e98f52f3617cae44ba96a557defaec2#diff-ba3deb473dd53b89625d05fa991dba12b5306b93400016e02d8f2af9678c3e2fR221

Had nothing to do with multiplayer itself. You just had a typo that made the sever's UID not match the client's UID. A single character typo.
If you're not going to bother looking into something so simple to fix entire non-singleplayer functionality, why are you working on this at all?